### PR TITLE
Add support for additional MIDI system and real-time events in deseri…

### DIFF
--- a/src/event.ts
+++ b/src/event.ts
@@ -49,7 +49,7 @@ export interface PortPrefixEvent extends MetaEvent<"portPrefix"> {
   port: number
 }
 
-export interface EndOfTrackEvent extends MetaEvent<"endOfTrack"> {}
+export interface EndOfTrackEvent extends MetaEvent<"endOfTrack"> { }
 
 export interface SetTempoEvent extends MetaEvent<"setTempo"> {
   microsecondsPerBeat: number
@@ -139,6 +139,64 @@ export interface SysExEvent extends Event<"sysEx"> {
 export interface DividedSysExEvent extends Event<"dividedSysEx"> {
   data: number[]
 }
+// System Common Events
+export interface TimeCodeQuarterFrameEvent {
+  deltaTime: number;
+  type: "system";
+  subtype: "timeCodeQuarterFrame";
+  data: number;
+}
+
+export interface SongPositionPointerEvent {
+  deltaTime: number;
+  type: "system";
+  subtype: "songPositionPointer";
+  value: number; // 14-bit value
+}
+
+export interface SongSelectEvent {
+  deltaTime: number;
+  type: "system";
+  subtype: "songSelect";
+  songNumber: number;
+}
+
+export interface TuneRequestEvent {
+  deltaTime: number;
+  type: "system";
+  subtype: "tuneRequest";
+}
+
+// Real-Time Events
+export interface TimingClockEvent {
+  deltaTime: number;
+  type: "system";
+  subtype: "timingClock";
+}
+
+export interface StartEvent {
+  deltaTime: number;
+  type: "system";
+  subtype: "start";
+}
+
+export interface ContinueEvent {
+  deltaTime: number;
+  type: "system";
+  subtype: "continue";
+}
+
+export interface StopEvent {
+  deltaTime: number;
+  type: "system";
+  subtype: "stop";
+}
+
+export interface ActiveSensingEvent {
+  deltaTime: number;
+  type: "system";
+  subtype: "activeSensing";
+}
 
 export type AnyMetaEvent =
   | SequenceNumberEvent
@@ -169,6 +227,6 @@ export type AnyChannelEvent =
   | UnknownChannelEvent
   | ControllerEvent
 
-export type AnySysExEvent = SysExEvent | DividedSysExEvent
+export type AnySysExEvent = SysExEvent | DividedSysExEvent | TimeCodeQuarterFrameEvent | SongPositionPointerEvent | SongSelectEvent | TuneRequestEvent | TimingClockEvent | StartEvent | ContinueEvent | StopEvent | ActiveSensingEvent
 
 export type AnyEvent = AnyMetaEvent | AnySysExEvent | AnyChannelEvent


### PR DESCRIPTION
I enconuntered the below problem while connecting my digital keyboard with signal application
```
deserialize.ts:250 Uncaught Error: Unrecognised MIDI event type byte: 254
    at MIDIMonitor.onMessage (MIDIMonitor.ts:11:41)
    at RootStore.ts:54:24
    at MIDIInput.ts:23:42
    at Array.forEach (<anonymous>)
    at MIDIInput.onMidiMessage (MIDIInput.ts:23:20)
onMessage	@	MIDIMonitor.ts:11
(anonymous)	@	RootStore.ts:54
(anonymous)	@	MIDIInput.ts:23
onMidiMessage	@	MIDIInput.ts:23
5
deserialize.ts:250 Uncaught Error: Unrecognised MIDI event type byte: 248
    at MIDIMonitor.onMessage (MIDIMonitor.ts:11:41)
    at RootStore.ts:54:24
    at MIDIInput.ts:23:42
    at Array.forEach (<anonymous>)
    at MIDIInput.onMidiMessage (MIDIInput.ts:23:20)
onMessage	@	MIDIMonitor.ts:11
(anonymous)	@	RootStore.ts:54
(anonymous)	@	MIDIInput.ts:23
onMidiMessage	@	MIDIInput.ts:23

```

So I created this fix 